### PR TITLE
Fix root-relative links by correcting `:blog-prefix.

### DIFF
--- a/content/asc/pages/about.asc
+++ b/content/asc/pages/about.asc
@@ -4,8 +4,6 @@
  :navbar? true
 }
 
-:toc:
-
 
 Hi, my name is https://jurajmartinka.com/[Juraj Martinka^] and I’m the author of the Curious (Clojure) Programmer blog.
 I’ve created this blog with following goals in my mind:

--- a/content/asc/pages/my-talks.asc
+++ b/content/asc/pages/my-talks.asc
@@ -9,7 +9,7 @@
 
 ### https://www.meetup.com/gdgjihlava/events/265293406/[Beyond Technical Debt: Unconventional techniques to uncover technical and social issues in your code^]
 
-link:../content/GdgJihlava-CodeScene.pdf[Slides (PDF)]
+link:/content/GdgJihlava-CodeScene.pdf[Slides (PDF)]
 
 Abstract:
 
@@ -40,5 +40,5 @@ Youtube video (audio + slides): https://youtu.be/YeUOWaM_Gk8
 
 Slides: https://www.slideshare.net/FPBrno/fpbrno-20171024-clojure-a-functional-lisp-on-the-jvm/
 
-link:../posts/2017-11-01-functional-programming-brno-meetup-clojure[Summary]
+link:/posts/2017-11-01-functional-programming-brno-meetup-clojure[Summary]
 

--- a/content/asc/pages/weekly-bits.asc
+++ b/content/asc/pages/weekly-bits.asc
@@ -5,7 +5,7 @@
 
 :toc:
 
-See link:../tags/weekly-bits[All "Weekly Bits & Pieces" posts].
+See link:/tags/weekly-bits[All "Weekly Bits & Pieces" posts].
 
 Weekly summaries of interesting, surprising, and worth-to-remember concepts, facts, ideas, experiences, events, tools/libraries, etc.
 It’s something that I did, learned, or found in the past week.

--- a/content/asc/posts/2017-03-08-my-bookshelf-create-a-project-skeleton-for-clojure-web-application.adoc
+++ b/content/asc/posts/2017-03-08-my-bookshelf-create-a-project-skeleton-for-clojure-web-application.adoc
@@ -136,7 +136,7 @@ We just want to show a static text.
 
 Now run the application (if you haven't run it already) and open the main page in a browser:
 
-image::../img/my-bookshelf-01-300x99.png[]
+image::/img/my-bookshelf-01-300x99.png[]
 
 == Conclusion
 

--- a/content/asc/posts/2018-02-10-defn-podcast-episode-30-zach-tellman.adoc
+++ b/content/asc/posts/2018-02-10-defn-podcast-episode-30-zach-tellman.adoc
@@ -59,14 +59,12 @@ In some situations, it could be better to be explicit: e.g., requiring a default
 ** _Why STM hasn't been as successful as expected_
 *** STM makes things much more complicated (compared to a simple atom) while it gives us only small benefits (mostly under heavy contention).
 *** We usually don't write systems with that heavy concurrency - we instead scale them by distributing load over multiple machines.
-
 ** _core.async_ is mostly useful on the client side (ClojureScript)
 *** People often use it on the server side even if there's no compelling reason to do so.
 
 * *Laziness*
 ** It can be tricky because there's no clear distinction between data in the process and outside the process (file, network, etc.)
 *** Here's further discussion about push & pull concepts: https://groups.google.com/forum/#!msg/elements-of-clojure/qPd--oNq7IU/vEXNtvsPAgAJ[_Question: Not able to understand function pull, push and transform_]
-
 ** If Rich had known about transducers before Clojure 1.0 release, he would have made the laziness much less a default option in Clojure.
 
 * *Light Table*

--- a/content/asc/posts/2020-05-04-weekly.asc
+++ b/content/asc/posts/2020-05-04-weekly.asc
@@ -158,9 +158,9 @@ ret
 * _Random Walk_ example in section 4.7 was pretty interesting - I don't think I ever heard
 about _first crossing time_ value:
 +
-image::../img/2020-05-04-weekly/ds-random-walk-python.png[Random Walk using plain python]
+image::/img/2020-05-04-weekly/ds-random-walk-python.png[Random Walk using plain python]
 +
-image::../img/2020-05-04-weekly/ds-random-walk-numpy.png[Random Walk using NumPy]
+image::/img/2020-05-04-weekly/ds-random-walk-numpy.png[Random Walk using NumPy]
 
 ### SICP
 
@@ -203,10 +203,10 @@ is really a _prefix code_!
 
 * Diassembled object code: `objdump -d mstore.o`
 +
-image::../img/2020-05-04-weekly/cs-objdump-object-code.png[Disassemble object code]
+image::/img/2020-05-04-weekly/cs-objdump-object-code.png[Disassemble object code]
 * Disassembled executable: `objdump -d prog`
 +
-image::../img/2020-05-04-weekly/cs-objdump-executable.png[Disassemble object code]
+image::/img/2020-05-04-weekly/cs-objdump-executable.png[Disassemble object code]
 
 You can find my book code examples here: https://github.com/jumarko/computer-systems
 
@@ -255,7 +255,7 @@ and deploying CodeScene with Azure Containers
 
 First, they tried to run CodeScene using our docker image and hit a JVM bug right from the start:
 
-image::../img/2020-05-04-weekly/codescene-avx-bug.png[SIGILL JVM error]
+image::/img/2020-05-04-weekly/codescene-avx-bug.png[SIGILL JVM error]
 
 As my colleague found, this was due to incorrect detection of AVX instruction family support 
 (vectorized processor instructions) in the JVM.
@@ -274,7 +274,7 @@ if there's 'avx' or not:
 As we later found, the AVX instruction wasn't supported due to "Compatibility Configuration"
 on the Windows Server host which allowed the VMs to be easily migrated between physical hosts:
 
-image::../img/2020-05-04-weekly/codescene-avx-bug-vm-compatibility.png[Windows Server - VM compability configuration]
+image::/img/2020-05-04-weekly/codescene-avx-bug-vm-compatibility.png[Windows Server - VM compability configuration]
 
 The customer ended up using Tomcat installed directly on the Host Windows OS,
 but it was a really tricky support case anyway.
@@ -291,7 +291,7 @@ although the machine had 32 GB of ram, the default Max heap size set by Tomcat W
 was only about ~250 MB.
 After raising the max heap size manually to 12 GB the analysis finished within a hour (they have a huge repository):
 
-image::../img/2020-05-04-weekly/codescene-windows-tomcat-heap-settings.png[lscpu - missing AVX flag]
+image::/img/2020-05-04-weekly/codescene-windows-tomcat-heap-settings.png[lscpu - missing AVX flag]
 
 #### Azure Containers - (really) slow IO
 

--- a/content/asc/posts/2020-05-11-weekly.asc
+++ b/content/asc/posts/2020-05-11-weekly.asc
@@ -130,7 +130,7 @@ and _polar_, within the same program, and how that fits into broader **Stratifie
 and also https://dspace.mit.edu/bitstream/handle/1721.1/6064/AIM-986.pdf;jsessionid=9B6B8F279FDAC150B9DCA19858ECB6A6?sequence=2[Lisp: A Language for Stratified Design]
 
 
-image::../img/2020-05-11-weekly/sicp_multiple-data-representations_layers.jpg[SICP Figure 2.21 Structure of the generic complex-arithmetic system,600,450]
+image::/img/2020-05-11-weekly/sicp_multiple-data-representations_layers.jpg[SICP Figure 2.21 Structure of the generic complex-arithmetic system,600,450]
 
 You can find relevant code here in my
 https://github.com/jumarko/clojure-experiments/blob/master/src/clojure_experiments/books/sicp/ch2_abstractions_data/s4_multiple_representations.clj#L137-L224[clojure-experiments repository].
@@ -142,7 +142,7 @@ I spent a quick 20-minute session by reading the chapter 3 (about machine code &
 I learned about the differences between the (frequently used) ATT (AT&T) assembly syntax
 and the Intel's assembly format: https://www.ibiblio.org/gferg/ldp/GCC-Inline-Assembly-HOWTO.html
 
-image::../img/2020-05-11-weekly/cs-intel-vs-att-assembly.jpg[Intel vs. ATT assembly format]
+image::/img/2020-05-11-weekly/cs-intel-vs-att-assembly.jpg[Intel vs. ATT assembly format]
 
 
 **A few notable differences:**

--- a/content/asc/posts/2022-01-12-moving-to-cryogen.asc
+++ b/content/asc/posts/2022-01-12-moving-to-cryogen.asc
@@ -120,7 +120,12 @@ The promise is that, unlike Markdown, it's standardized, extensible and has rich
 ----
 link:/posts/2017-11-01-functional-programming-brno-meetup-clojure[Summary]
 ----
-** *UPDATE*: I was wrong - root-relative links DO work, I just had an incorrect configuration in my [`config.edn` file]
+** *UPDATE*: I was wrong - root-relative links DO work, I just had an incorrect configuration in my https://github.com/curiousprogrammer-net/curiousprogrammer.blog/pull/18[`config.edn` file]
++
+[source,asciidoc]
+----
+:blog-prefix ""
+----
 * Always use *_\*_* for list items, DO NOT USE `-`.
 ** `_` works only for top-level lists, not nested lists.
 * Prefer explicit `:toc:` for generating Table of Contents

--- a/content/asc/posts/2022-01-12-moving-to-cryogen.asc
+++ b/content/asc/posts/2022-01-12-moving-to-cryogen.asc
@@ -76,7 +76,7 @@ DevEx footnote:[Developer Experience] is very nice out of the box.
 Consider https://github.com/curiousprogrammer-net/curiousprogrammer.blog/pull/14[this example of a pull request build]
 which automatically produces a test version containing the suggested changes:
 
-image::../img/cloudflare-pages-pr-build.png[]
+image::/img/cloudflare-pages-pr-build.png[]
 
 
 If you are interested,
@@ -118,8 +118,9 @@ The promise is that, unlike Markdown, it's standardized, extensible and has rich
 +
 [source,asciidoc]
 ----
-link:../posts/2017-11-01-functional-programming-brno-meetup-clojure[Summary]
+link:/posts/2017-11-01-functional-programming-brno-meetup-clojure[Summary]
 ----
+** *UPDATE*: I was wrong - root-relative links DO work, I just had an incorrect configuration in my [`config.edn` file]
 * Always use *_\*_* for list items, DO NOT USE `-`.
 ** `_` works only for top-level lists, not nested lists.
 * Prefer explicit `:toc:` for generating Table of Contents

--- a/content/config.edn
+++ b/content/config.edn
@@ -10,7 +10,7 @@
  :tag-root-uri                 "tags"
  :author-root-uri              "authors"
  :public-dest                  "public"
- :blog-prefix                  "/"
+ :blog-prefix                  ""
  :rss-name                     "feed.xml"
  :rss-filters                  ["cryogen"]
  :recent-posts                 5


### PR DESCRIPTION
Changing blog prefix from "/" to "" is all that's needed.
I got confused because the generated config was for blog hosted under context path ("/blog" or equivalent)
and I changed it to "/" very early on without thinking about it much.

This makes links work as expected:

```
 :blog-prefix                  ""
```