### PR TITLE
First draft for the lein uberjar dependency problem (duct.core.repl -> fipp).

### DIFF
--- a/content/asc/posts/2022-08-24-lein-uberjar-dependency-problem.asc
+++ b/content/asc/posts/2022-08-24-lein-uberjar-dependency-problem.asc
@@ -1,0 +1,278 @@
+{
+:date "2022-08-24"
+:title "Leiningen, uberjars and a mysterious \"dev-only\" dependency problem."
+:layout :post
+:tags  ["clojure" "leiningen" "dependencies"]
+}
+
+:toc:
+
+
+Let me tell you a story about debugging a problem
+with our CI build including unexpected dependencies via `lein uberjar`.
+
+
+## Intro
+
+Recently, we spotted a problem in our CodeScene test environment - the https://hub.docker.com/r/empear/codescene[codescene docker container^]
+would not start.
+The app failed early in the initialization sequence with a mysterious dependency error:
+
+[source]
+----
+Exception in thread "main" java.lang.ExceptionInInitializerError
+Caused by: Syntax error macroexpanding at (duct/core/repl.clj:1:1).
+at clojure.lang.Compiler.load(Compiler.java:7665)
+at clojure.lang.RT.loadResourceScript(RT.java:381)
+...
+at user$eval138$loading__6789__auto____139.invoke(user.clj:1)
+at user$eval138.invokeStatic(user.clj:1)
+at user$eval138.invoke(user.clj:1)
+at clojure.lang.Compiler.eval(Compiler.java:7194)
+...
+at ***.core.<clinit>(Unknown Source)
+Caused by: java.io.FileNotFoundException: Could not locate fipp/ednize__init.class, fipp/ednize.clj or fipp/ednize.cljc on classpath.
+at clojure.lang.RT.load(RT.java:462)
+...
+at clojure.core$require.doInvoke(core.clj:6038)
+at clojure.lang.RestFn.invoke(RestFn.java:482)
+at duct.core.repl$eval1257$loading__6789__auto____1258.invoke(repl.clj:1)
+at duct.core.repl$eval1257.invokeStatic(repl.clj:1)
+at duct.core.repl$eval1257.invoke(repl.clj:1)
+at clojure.lang.Compiler.eval(Compiler.java:7194)
+at clojure.lang.Compiler.eval(Compiler.java:7183)
+at clojure.lang.Compiler.load(Compiler.java:7653)
+... 35 more
+----
+
+
+## Debugging
+
+### Reproduce the problem
+
+The first step should be to reproduce the bug yourself.
+**See it fail** - on your machine.
+
+Obviously, everything was working in the REPL (otherwise we would have found the problem earlier),
+but the uberjar was not starting.
+
+I ran the build script on my laptop and tried to run it via `java -jar ...`.
+It worked without a problem.
+
+Then I built a whole docker image and try to run it.
+That worked too...
+
+### Welcome to the (CI) caves!
+
+I was thinking: "there must be some difference between my laptop (macOS) and the GitHub Actions machine (Ubuntu)".
+
+The first idea: different versions of Java.
+But how could that cause the problem?
+So maybe leiningen?
+
+Let's see what I had locally:
+
+[source,bash]
+----
+lein --version
+Leiningen 2.9.8 on Java 17.0.2 OpenJDK 64-Bit Server VM
+----
+
+But how to find out the version that the CI uses?
+Perhaps by debugging the build?
+
+I found the convenient
+https://github.com/marketplace/actions/debug-via-ssh[_debug-via-ssh_ action^]
+on GitHub Marketplace.
+I added it to our CI workflow, restarted the build and connected via SSH to the machine.
+There I ran the same `lein version` command as before:
+
+[source,bash]
+----
+lein --version
+Leiningen 2.9.9 on Java 11.0.16 OpenJDK 64-Bit Server VM
+----
+
+Hmm, Ok. So the Java version was different but I wasn't sure how that could affect the problem.
+Besides, I also tried Java 8 before and it worked.footnote:[Our build uses Java 8 too, but GitHub actions come with Java 11 preinstalled. Later in the workflow file, we specify that we want Java 8 and that is used for the actual build]
+
+Then maybe leiningen?
+I decided to upgrade it on my machine:
+
+[source,bash]
+----
+brew upgrade leiningen
+...
+lein --version
+Leiningen 2.9.9 ...
+----
+
+Then made a new build and run it again.
+Finally, got the same error!
+
+
+
+## Digging in
+
+We had the reproducer - a good start.
+
+Now back to the stacktrace.
+The key message there is `Could not locate fipp/ednize__init.class`
+
+[source,bash]
+----
+Caused by: java.io.FileNotFoundException: Could not locate fipp/ednize__init.class, fipp/ednize.clj or fipp/ednize.cljc on classpath.
+----
+
+It suggests a missing or conflicting (version) dependency - in this case, the https://github.com/brandonbloom/fipp[fipp library^].
+
+This was surprising because everything was working on our machines
+and tests run on the same CI (GitHub Actions) machines were passing too.
+
+
+Reading the stacktrace, we can see that:
+
+1. There's a problem in `duct/core/repl.clj` file
+2. This file is being loaded via some `user.clj` file on the classpath
+3. `user.clj` is requiring, at least transitively, `duct.core.repl`
+4. `duct.core.repl` https://github.com/duct-framework/core/blob/master/src/duct/core/repl.clj#L3[requires _fipp.ednize_^]
+
+But wait, what `user.clj`?
+How come there's `user.clj` on the classpath when we don't have it anywhere in our production depedencies?
+
+
+### Exploiting the JAR
+
+To answer those questions, I decided to dig into the JAR file.
+I had a broken docker image, so it was easy to
+https://www.thecodebuzz.com/how-to-list-files-in-a-stopped-docker-container-paused-container/[copy the JAR file from the container to my host OS^].
+
+Opening the JAR with a Midnight Commander (JAR is just a special zip archive) lead to a surprise:
+there was `user.clj` right in the JAR's root.
+
+By looking at the file content, I could see that this is `user.clj`
+from one our modules that we include as a dependency in the application.
+This file indeed requires `duct.core.repl` which requires `fipp.ednize`.
+
+But this `user.clj` was a dev-only source file (in the `dev/src` directory)
+that was specifically included only in leiningen's `dev` profile
+in the module's `project.clj`:
+
+[source,clojure]
+----
+  :profiles {:dev {:dependencies [[fipp "0.6.24"]
+                                  ... ]
+                   :source-paths ["dev/src"]}}
+----
+
+## Looking for advice
+
+I figured out why it's happening ("dev-only" user.clj file present in the uberjar)
+but not how to fix it.
+
+To learn more, I turned, as many times before, to the Clojurians slack channel.
+I https://clojurians.slack.com/archives/C0AB48493/p1660126479775579[posted a question in the #leiningen channel^]
+hoping that somebody can help me find the reason.
+
+Very soon, I got an
+https://clojurians.slack.com/archives/C0AB48493/p1660133187826479?thread_ts=1660126479.775579&cid=C0AB48493[advice to exclude the dev profile^]
+via `lein with-profile -dev ...`:
+
+[quote, vemv on Slack]
+____
+For a few years I've invoked all important commands with an with-profile -dev  - one never knows when that implicit profile might be activated
+____
+
+A couple of hours later, 
+https://clojurians.slack.com/archives/C0AB48493/p1660136629791009?thread_ts=1660126479.775579&cid=C0AB48493[I learned about the root cause^]: 
+
+[quote, Esko on Slack]
+____
+This is a known bug in 2.9.9, as soon as it was noticed yesterday technomancy jumped on it and started fixing it.
+It is recommended to stay on 2.9.8 and wait until 2.9.10 if possible; the bug has been fixed, but turns out to be one of those things where fixing one bug introduces another one.
+
+Because of move to Codeberg there’s nothing on the GitHub side about this;
+the issue in question is being tracked here https://codeberg.org/leiningen/leiningen/issues/5
+
+Recommended workaround is `lein with-profile production uberjar`
+____
+
+Excellent, I learned why exactly it's happening with lein 2.9.9 and a couple of approaches to solve it.
+Now, let's fix it!
+
+## Resolution
+
+First, I thought: _Simply downgrade leiningen to the previous version_ (2.9.8).
+However, this turned out to be a bit more complicated than I hoped.
+Leiningen is automatically installed (and updated) on all GitHub Actions nodes.
+That is convenient and useful.
+
+Thus I leaned toward the workaround suggested on Slack - make sure to turn off the dev profile
+or specify the `production` profile explicitly, when installing the dependencies:
+
+[source,bash]
+----
+lein with-profile production install
+----
+
+And to be safe, do the same thing when building the uberjar:
+
+[source,bash]
+----
+	lein with-profile production uberjar
+----
+
+I updated our build script and verified that everything worked as before.
+Sweet!
+
+
+## Parting thoughts
+
+Build tools (as all sofware) have bugs and sometimes break unexpectedly.
+Automatic version updates are convenient
+but can break your software "without a reason"
+and no change on your side.
+
+* Make sure to know your tools and review how you are using them. When in doubt, ask experts - there's plenty of free advice out there!
+* (Maybe) fix versions of the tools and use the same versions in both CI and development. If you do so, make sure to review and update the versions reguarly. 
+
+
+
+
+
+## Resources
+
+* The leiningen bug: https://codeberg.org/leiningen/leiningen/issues/5
+** Fixed in 2.9.10: https://codeberg.org/leiningen/leiningen/releases
++
+[quote]
+____
+Fix a bug where dev-resources could leak into jars/uberjars.
+____
+
+* https://clojurians.slack.com/archives/C0AB48493/p1660126479775579[My **question on Clojurians slack in the #leiningen channel**^]
+
+* https://github.com/duct-framework/core/blob/master/src/duct/core/repl.clj#L3[`duct.core.repl` source^]
+** see also https://github.com/duct-framework/core/blob/master/project.clj#L10[duct-framework/core's project.clj^] referencing `fipp` dependency
+* Related https://clojureverse.org/t/noclassdeffounderror-clout-core-compiledroute-with-compjure-liberator-and-ring-possibly/2682/2[clojureverse discussion^]:
++
+[quote, Matthias Varberg Ingesman]
+____
+To me it looks like your **user.clj** somehow ended up in your uberjar.
+____
+
+* GitHub Actions - the list of https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2004-Readme.md[software preinstalled on the ubuntu image^]
+
+* A clojure.org guide mentioning _user.clj_: https://clojure.org/guides/dev_startup_time
++
+[quote]
+____
+user.clj file loaded automatically by the Clojure runtime, before any other code is loaded.
+____
+* ClojureVerse discussion: https://clojureverse.org/t/how-are-user-clj-files-loaded/3842[How are `user.clj` files loaded?^]
++
+[quote, AlexMiller]
+____
+Clojure looks for the first user.clj file on the classpath during runtime initialization. So if there are multiple ones, which one it finds first is entirely dependent on the order of your classpath. 
+____
+

--- a/content/asc/posts/2022-08-24-lein-uberjar-dependency-problem.asc
+++ b/content/asc/posts/2022-08-24-lein-uberjar-dependency-problem.asc
@@ -149,7 +149,7 @@ To answer those questions, I decided to dig into the JAR file.
 I had a broken docker image, so it was easy to
 https://www.thecodebuzz.com/how-to-list-files-in-a-stopped-docker-container-paused-container/[copy the JAR file from the container to my host OS^].
 
-Opening the JAR with a Midnight Commander (JAR is just a special zip archive) lead to a surprise:
+Opening the JAR with Midnight Commander (JAR is just a special zip archive) lead to a surprise:
 there was `user.clj` right in the JAR's root.
 
 By looking at the file content, I could see that this is `user.clj`

--- a/content/asc/posts/2022-08-24-lein-uberjar-dependency-problem.asc
+++ b/content/asc/posts/2022-08-24-lein-uberjar-dependency-problem.asc
@@ -107,7 +107,7 @@ lein --version
 Leiningen 2.9.9 ...
 ----
 
-Then made a new build and run it again.
+Then made a new build and ran it again.
 Finally, got the same error!
 
 
@@ -127,7 +127,7 @@ Caused by: java.io.FileNotFoundException: Could not locate fipp/ednize__init.cla
 It suggests a missing or conflicting (version) dependency - in this case, the https://github.com/brandonbloom/fipp[fipp library^].
 
 This was surprising because everything was working on our machines
-and tests run on the same CI (GitHub Actions) machines were passing too.
+and the CI tests were passing too.
 
 
 Reading the stacktrace, we can see that:
@@ -170,9 +170,9 @@ in the module's `project.clj`:
 I figured out why it's happening ("dev-only" user.clj file present in the uberjar)
 but not how to fix it.
 
-To learn more, I turned, as many times before, to the Clojurians slack channel.
+To learn more, I turned to, as many times before, the Clojurians slack channel.
 I https://clojurians.slack.com/archives/C0AB48493/p1660126479775579[posted a question in the #leiningen channel^]
-hoping that somebody can help me find the reason.
+hoping that somebody could help me find the reason.
 
 Very soon, I got an
 https://clojurians.slack.com/archives/C0AB48493/p1660133187826479?thread_ts=1660126479.775579&cid=C0AB48493[advice to exclude the dev profile^]
@@ -194,7 +194,7 @@ It is recommended to stay on 2.9.8 and wait until 2.9.10 if possible; the bug ha
 Because of move to Codeberg there’s nothing on the GitHub side about this;
 the issue in question is being tracked here https://codeberg.org/leiningen/leiningen/issues/5
 
-Recommended workaround is `lein with-profile production uberjar`
+Recommended workaround is *`lein with-profile production uberjar`*
 ____
 
 Excellent, I learned why exactly it's happening with lein 2.9.9 and a couple of approaches to solve it.
@@ -219,7 +219,7 @@ And to be safe, do the same thing when building the uberjar:
 
 [source,bash]
 ----
-	lein with-profile production uberjar
+lein with-profile production uberjar
 ----
 
 I updated our build script and verified that everything worked as before.

--- a/content/asc/posts/2022-08-24-lein-uberjar-dependency-problem.asc
+++ b/content/asc/posts/2022-08-24-lein-uberjar-dependency-problem.asc
@@ -7,6 +7,8 @@
 
 :toc:
 
+_This post has also been published on CodeScene Engineering blog: https://codescene.com/engineering-blog_.
+
 
 Let me tell you a story about debugging a problem
 with our CI build including unexpected dependencies via `lein uberjar`.

--- a/content/asc/posts/2022-08-24-lein-uberjar-dependency-problem.asc
+++ b/content/asc/posts/2022-08-24-lein-uberjar-dependency-problem.asc
@@ -59,7 +59,7 @@ but the uberjar was not starting.
 I ran the build script on my laptop and tried to run it via `java -jar ...`.
 It worked without a problem.
 
-Then I built a whole docker image and try to run it.
+Then I built a whole docker image and tried to run it.
 That worked too...
 
 ### Welcome to the (CI) caves!
@@ -207,7 +207,7 @@ However, this turned out to be a bit more complicated than I hoped.
 Leiningen is automatically installed (and updated) on all GitHub Actions nodes.
 That is convenient and useful.
 
-Thus I leaned toward the workaround suggested on Slack - make sure to turn off the dev profile
+Thus I leaned toward the workaround suggested on Slack: make sure to turn off the dev profile
 or specify the `production` profile explicitly, when installing the dependencies:
 
 [source,bash]
@@ -228,13 +228,13 @@ Sweet!
 
 ## Parting thoughts
 
-Build tools (as all sofware) have bugs and sometimes break unexpectedly.
+Build tools (as all software) have bugs and sometimes break unexpectedly.
 Automatic version updates are convenient
 but can break your software "without a reason"
 and no change on your side.
 
 * Make sure to know your tools and review how you are using them. When in doubt, ask experts - there's plenty of free advice out there!
-* (Maybe) fix versions of the tools and use the same versions in both CI and development. If you do so, make sure to review and update the versions reguarly. 
+* (Maybe) fix versions of the tools and use the same versions in both CI and development. If you do so, make sure to review and update the versions regularly. 
 
 
 


### PR DESCRIPTION
This is the problem we encountered early in August, 2022.
It happened both in cloud/worker and onprem test environment.